### PR TITLE
Explicit versions of stdlib fixes #2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "deno.enable": true,
+    "deno.lint": true,
+    "deno.unstable": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll": true,
+        "source.organizeImports": true
+    },
+    "editor.defaultFormatter": "denoland.vscode-deno",
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": false
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ console.log('Good Morning :)')
 // import { sleepRandomAmountOfSeconds } from "https://deno.land/x/sleep/mod.ts";
 
 // console.log('I should sleep')
-// await sleepRandomAmountOfSeconds(2, 4, true)
+// await sleepRandomAmountOfSeconds(2, 4)
 // console.log('Good Morning :)')
 
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,1 +1,1 @@
-export * from './sleep.ts'
+export * from "./sleep.ts";

--- a/sleep.ts
+++ b/sleep.ts
@@ -1,14 +1,15 @@
-export function sleep(seconds: number){
-    return new Promise((resolve) => setTimeout(resolve, seconds * 1000))
+export function sleep(seconds: number) {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 }
 
-export function sleepRandomAmountOfSeconds(minimumSeconds: number, maximumSeconds: number){
-    const secondsOfSleep = getRandomArbitrary(minimumSeconds, maximumSeconds)
-    return new Promise((resolve) => setTimeout(resolve, secondsOfSleep * 1000))
+export function sleepRandomAmountOfSeconds(
+  minimumSeconds: number,
+  maximumSeconds: number,
+) {
+  const secondsOfSleep = getRandomArbitrary(minimumSeconds, maximumSeconds);
+  return new Promise((resolve) => setTimeout(resolve, secondsOfSleep * 1000));
 }
 
 function getRandomArbitrary(min: number, max: number) {
-    return Math.random() * (max - min) + min
+  return Math.random() * (max - min) + min;
 }
-
-

--- a/sleep.ts
+++ b/sleep.ts
@@ -1,14 +1,9 @@
-import * as log from "https://deno.land/std/log/mod.ts";
-
 export function sleep(seconds: number){
     return new Promise((resolve) => setTimeout(resolve, seconds * 1000))
 }
 
-export function sleepRandomAmountOfSeconds(minimumSeconds: number, maximumSeconds: number, sleepLog: boolean = false){
+export function sleepRandomAmountOfSeconds(minimumSeconds: number, maximumSeconds: number){
     const secondsOfSleep = getRandomArbitrary(minimumSeconds, maximumSeconds)
-    if (sleepLog){
-        log.info(`I will sleep for ${secondsOfSleep} seconds.`)
-    }
     return new Promise((resolve) => setTimeout(resolve, secondsOfSleep * 1000))
 }
 

--- a/test.ts
+++ b/test.ts
@@ -2,23 +2,23 @@ import { fail } from "https://deno.land/std@0.97.0/testing/asserts.ts";
 import { sleep, sleepRandomAmountOfSeconds } from "./sleep.ts";
 
 Deno.test("sleep for 2 seconds", async (): Promise<void> => {
-
-    const sleepStartAt = Date.now()
-    await sleep(2)
-    const sleepEndAt = Date.now()
-    const sleepDuration = sleepEndAt - sleepStartAt
-    if (sleepDuration < 2000 || sleepDuration > 2100){
-        fail('you should somehow relax')
-    }
+  const sleepStartAt = Date.now();
+  await sleep(2);
+  const sleepEndAt = Date.now();
+  const sleepDuration = sleepEndAt - sleepStartAt;
+  if (sleepDuration < 2000 || sleepDuration > 2100) {
+    fail("you should somehow relax");
+  }
 });
 
-Deno.test("sleep for random amount of seconds between 2 and 4 seconds", async (): Promise<void> => {
-
-    const sleepStartAt = Date.now()
-    await sleepRandomAmountOfSeconds(2, 4)
-    const sleepEndAt = Date.now()
-    const sleepDuration = sleepEndAt - sleepStartAt
-    if (sleepDuration < 2000 || sleepDuration > 4100){
-        fail('you should somehow relax')
-    }
+Deno.test("sleep for random amount of seconds between 2 and 4 seconds", async (): Promise<
+  void
+> => {
+  const sleepStartAt = Date.now();
+  await sleepRandomAmountOfSeconds(2, 4);
+  const sleepEndAt = Date.now();
+  const sleepDuration = sleepEndAt - sleepStartAt;
+  if (sleepDuration < 2000 || sleepDuration > 4100) {
+    fail("you should somehow relax");
+  }
 });

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,5 @@
-import { fail } from "https://deno.land/std/testing/asserts.ts";
-import { sleep, sleepRandomAmountOfSeconds } from "https://deno.land/x/sleep/mod.ts";
+import { fail } from "https://deno.land/std@0.97.0/testing/asserts.ts";
+import { sleep, sleepRandomAmountOfSeconds } from "./sleep.ts";
 
 Deno.test("sleep for 2 seconds", async (): Promise<void> => {
 
@@ -15,7 +15,7 @@ Deno.test("sleep for 2 seconds", async (): Promise<void> => {
 Deno.test("sleep for random amount of seconds between 2 and 4 seconds", async (): Promise<void> => {
 
     const sleepStartAt = Date.now()
-    await sleepRandomAmountOfSeconds(2, 4, true)
+    await sleepRandomAmountOfSeconds(2, 4)
     const sleepEndAt = Date.now()
     const sleepDuration = sleepEndAt - sleepStartAt
     if (sleepDuration < 2000 || sleepDuration > 4100){

--- a/usage-example-advanced.ts
+++ b/usage-example-advanced.ts
@@ -1,6 +1,6 @@
-import { sleepRandomAmountOfSeconds } from "https://deno.land/x/sleep/mod.ts";
+import { sleepRandomAmountOfSeconds } from "./sleep.ts";
 
 console.log('I should sleep')
-await sleepRandomAmountOfSeconds(2, 4, true)
+await sleepRandomAmountOfSeconds(2, 4)
 console.log('Good Morning :)')
 

--- a/usage-example-advanced.ts
+++ b/usage-example-advanced.ts
@@ -1,6 +1,5 @@
 import { sleepRandomAmountOfSeconds } from "./sleep.ts";
 
-console.log('I should sleep')
-await sleepRandomAmountOfSeconds(2, 4)
-console.log('Good Morning :)')
-
+console.log("I should sleep");
+await sleepRandomAmountOfSeconds(2, 4);
+console.log("Good Morning :)");

--- a/usage-example.ts
+++ b/usage-example.ts
@@ -1,5 +1,4 @@
-import { sleep } from "https://deno.land/x/sleep/mod.ts";
-// import { sleep } from "./sleep.ts";
+import { sleep } from "./sleep.ts";
 
 console.log('I should sleep')
 await sleep(3)

--- a/usage-example.ts
+++ b/usage-example.ts
@@ -1,6 +1,5 @@
 import { sleep } from "./sleep.ts";
 
-console.log('I should sleep')
-await sleep(3)
-console.log('Good Morning :)')
-
+console.log("I should sleep");
+await sleep(3);
+console.log("Good Morning :)");


### PR DESCRIPTION
I took a more comprehensive approach to resolving #2, which is to remove the offending log import altogether as it didn't really feel appropriate that a tiny lib should write to stdout via `log` statement and also fix the imports in test and example code.

Resolved:

* remove log statement and config from sleep.ts and README.md
* specify explicit version of stdlib in test.ts
* do NOT test against a published version, test against local sleep.ts
* update examples to use local code

It was both the main lib code and the test code that was causing issues as found in https://github.com/denoland/deno/issues/10799#issuecomment-854019680